### PR TITLE
Add multi-architecture tests

### DIFF
--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -6,11 +6,11 @@ on:
       - 'v*'
 jobs:
   tests:
-    name: Tests on ${{ matrix.arch }}
-    runs-on: ubuntu-latest
+    name: Tests on ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
     strategy:
         matrix:
-            arch: [amd64, arm64]
+          runner: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@v4
       - name: Tests

--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -6,8 +6,11 @@ on:
       - 'v*'
 jobs:
   tests:
-    name: Tests
+    name: Tests on ${{ matrix.arch }}
     runs-on: ubuntu-latest
+    strategy:
+        matrix:
+            arch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v4
       - name: Tests

--- a/.github/workflows/prs.yaml
+++ b/.github/workflows/prs.yaml
@@ -7,10 +7,11 @@ on:
       - master
 jobs:
   tests:
-    name: Tests
-    runs-on:
-      - ubuntu-latest
-      - ubuntu-24.04-arm
+    name: Tests on ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@v4
       - name: Tests

--- a/.github/workflows/prs.yaml
+++ b/.github/workflows/prs.yaml
@@ -7,7 +7,7 @@ on:
       - master
 jobs:
   tests:
-    name: Tests on ${{ matrix.arch }}
+    name: Tests
     runs-on:
       - ubuntu-latest
       - ubuntu-24.04-arm

--- a/.github/workflows/prs.yaml
+++ b/.github/workflows/prs.yaml
@@ -8,10 +8,9 @@ on:
 jobs:
   tests:
     name: Tests on ${{ matrix.arch }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [ amd64, arm64 ]
+    runs-on:
+      - ubuntu-latest
+      - ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - name: Tests

--- a/.github/workflows/prs.yaml
+++ b/.github/workflows/prs.yaml
@@ -7,8 +7,11 @@ on:
       - master
 jobs:
   tests:
-    name: Tests
+    name: Tests on ${{ matrix.arch }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [ amd64, arm64 ]
     steps:
       - uses: actions/checkout@v4
       - name: Tests

--- a/.github/workflows/test-clients.yaml
+++ b/.github/workflows/test-clients.yaml
@@ -26,8 +26,6 @@ jobs:
     needs:
       - build
     steps:
-      - name: Verify architecture
-        run: uname -m
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -72,9 +70,9 @@ jobs:
           #include-hidden-files: true
           name: beanstalkd-${{ matrix.runner }}
       - name: Make beanstalkd executable for ${{ matrix.runner }}
-        run: chmod +x ${{steps.download.outputs.download-path}}-${{ matrix.runner }}/beanstalkd
+        run: chmod +x ${{steps.download.outputs.download-path}}/beanstalkd
       - name: Run beanstalkd -v
-        run: ${{steps.download.outputs.download-path}}-${{ matrix.runner }}/beanstalkd -v
+        run: ${{steps.download.outputs.download-path}}/beanstalkd -v
 
       - name: Install dependencies
         run: |
@@ -82,7 +80,7 @@ jobs:
           pip install .
       - name: Run tests
         env:
-          BEANSTALKD_PATH: ${{steps.download.outputs.download-path}}-${{ matrix.runner }}/beanstalkd
+          BEANSTALKD_PATH: ${{steps.download.outputs.download-path}}/beanstalkd
         run: make test
   pystalk:
     name: Test Pystalk Python
@@ -107,12 +105,12 @@ jobs:
         with:
           name: beanstalkd-${{ matrix.runner }}
       - name: Make beanstalkd executable for ${{ matrix.runner }}
-        run: chmod +x ${{steps.download.outputs.download-path}}-${{ matrix.runner }}/beanstalkd
+        run: chmod +x ${{steps.download.outputs.download-path}}/beanstalkd
       - name: Run beanstalkd -v
-        run: ${{steps.download.outputs.download-path}}-${{ matrix.runner }}/beanstalkd -v
+        run: ${{steps.download.outputs.download-path}}/beanstalkd -v
       - name: Install dependencies
         run: python -m pip install -r requirements-tests.txt -e .
       - name: Run tests
         env:
-          BEANSTALKD_PATH: ${{steps.download.outputs.download-path}}-${{ matrix.runner }}/beanstalkd
+          BEANSTALKD_PATH: ${{steps.download.outputs.download-path}}/beanstalkd
         run: pytest tests/

--- a/.github/workflows/test-clients.yaml
+++ b/.github/workflows/test-clients.yaml
@@ -5,23 +5,23 @@ on:
 jobs:
   build:
     name: Build beanstalkd
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        arch: [ amd64, arm64 ]
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@v4
       - run: make
       - uses: actions/upload-artifact@v4
         with:
-          name: beanstalkd-${{ matrix.arch }}
+          name: beanstalkd-${{ matrix.runner }}
           path: beanstalkd
   pheanstalk:
     name: Test Pheanstalk PHP
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        arch: [ amd64, arm64 ]
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
     continue-on-error: true
     needs:
       - build
@@ -35,9 +35,9 @@ jobs:
           tools: phpunit
       - uses: actions/download-artifact@v4
         with:
-          name: beanstalkd-${{ matrix.arch }}
-      - name: Start beanstalkd for ${{ matrix.arch }}
-        run: chmod +x ./beanstalkd-${{ matrix.arch }} && ./beanstalkd-${{ matrix.arch }} &
+          name: beanstalkd-${{ matrix.runner }}
+      - name: Start beanstalkd for ${{ matrix.runner }}
+        run: chmod +x ./beanstalkd && ./beanstalkd &
       - uses: actions/checkout@v4
         with:
           repository: pheanstalk/pheanstalk
@@ -50,12 +50,12 @@ jobs:
           SERVER_HOST: localhost
   greenstalk:
     name: Test Greenstalk Python
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     continue-on-error: true
     strategy:
       matrix:
         python-version: [ 3.9 ]
-        arch: [ amd64, arm64 ]
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
     needs:
       - build
     steps:
@@ -70,11 +70,11 @@ jobs:
         id: download
         with:
           #include-hidden-files: true
-          name: beanstalkd-${{ matrix.arch }}
-      - name: Make beanstalkd executable for ${{ matrix.arch }}
-        run: chmod +x ${{steps.download.outputs.download-path}}/beanstalkd-${{ matrix.arch }}
+          name: beanstalkd-${{ matrix.runner }}
+      - name: Make beanstalkd executable for ${{ matrix.runner }}
+        run: chmod +x ${{steps.download.outputs.download-path}}-${{ matrix.runner }}/beanstalkd
       - name: Run beanstalkd -v
-        run: ${{steps.download.outputs.download-path}}/beanstalkd-${{ matrix.arch }} -v
+        run: ${{steps.download.outputs.download-path}}-${{ matrix.runner }}/beanstalkd -v
 
       - name: Install dependencies
         run: |
@@ -82,16 +82,16 @@ jobs:
           pip install .
       - name: Run tests
         env:
-          BEANSTALKD_PATH: ${{steps.download.outputs.download-path}}/beanstalkd-${{ matrix.arch }}
+          BEANSTALKD_PATH: ${{steps.download.outputs.download-path}}-${{ matrix.runner }}/beanstalkd
         run: make test
   pystalk:
     name: Test Pystalk Python
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     continue-on-error: true
     strategy:
       matrix:
         python-version: [ "3.10" ]
-        arch: [ amd64, arm64 ]
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
     needs:
       - build
     steps:
@@ -105,14 +105,14 @@ jobs:
       - uses: actions/download-artifact@v4
         id: download
         with:
-          name: beanstalkd-${{ matrix.arch }}
-      - name: Make beanstalkd executable for ${{ matrix.arch }}
-        run: chmod +x ${{steps.download.outputs.download-path}}/beanstalkd-${{ matrix.arch }}
+          name: beanstalkd-${{ matrix.runner }}
+      - name: Make beanstalkd executable for ${{ matrix.runner }}
+        run: chmod +x ${{steps.download.outputs.download-path}}-${{ matrix.runner }}/beanstalkd
       - name: Run beanstalkd -v
-        run: ${{steps.download.outputs.download-path}}/beanstalkd-${{ matrix.arch }} -v
+        run: ${{steps.download.outputs.download-path}}-${{ matrix.runner }}/beanstalkd -v
       - name: Install dependencies
         run: python -m pip install -r requirements-tests.txt -e .
       - name: Run tests
         env:
-          BEANSTALKD_PATH: ${{steps.download.outputs.download-path}}/beanstalkd-${{ matrix.arch }}
+          BEANSTALKD_PATH: ${{steps.download.outputs.download-path}}-${{ matrix.runner }}/beanstalkd
         run: pytest tests/

--- a/.github/workflows/test-clients.yaml
+++ b/.github/workflows/test-clients.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: beanstalkd-${{ matrix.arch }}
-          path: beanstalkd-${{ matrix.arch }}
+          path: beanstalkd
   pheanstalk:
     name: Test Pheanstalk PHP
     runs-on: ubuntu-latest

--- a/.github/workflows/test-clients.yaml
+++ b/.github/workflows/test-clients.yaml
@@ -6,20 +6,28 @@ jobs:
   build:
     name: Build beanstalkd
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [ amd64, arm64 ]
     steps:
       - uses: actions/checkout@v4
       - run: make
       - uses: actions/upload-artifact@v4
         with:
-          name: beanstalkd
-          path: beanstalkd
+          name: beanstalkd-${{ matrix.arch }}
+          path: beanstalkd-${{ matrix.arch }}
   pheanstalk:
     name: Test Pheanstalk PHP
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [ amd64, arm64 ]
     continue-on-error: true
     needs:
       - build
     steps:
+      - name: Verify architecture
+        run: uname -m
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -27,9 +35,9 @@ jobs:
           tools: phpunit
       - uses: actions/download-artifact@v4
         with:
-          name: beanstalkd
-      - name: Start beanstalkd
-        run: chmod +x ./beanstalkd && ./beanstalkd &
+          name: beanstalkd-${{ matrix.arch }}
+      - name: Start beanstalkd for ${{ matrix.arch }}
+        run: chmod +x ./beanstalkd-${{ matrix.arch }} && ./beanstalkd-${{ matrix.arch }} &
       - uses: actions/checkout@v4
         with:
           repository: pheanstalk/pheanstalk
@@ -47,6 +55,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ 3.9 ]
+        arch: [ amd64, arm64 ]
     needs:
       - build
     steps:
@@ -61,11 +70,11 @@ jobs:
         id: download
         with:
           #include-hidden-files: true
-          name: beanstalkd
-      - name: Make beanstalkd executable
-        run: chmod +x ${{steps.download.outputs.download-path}}/beanstalkd
+          name: beanstalkd-${{ matrix.arch }}
+      - name: Make beanstalkd executable for ${{ matrix.arch }}
+        run: chmod +x ${{steps.download.outputs.download-path}}/beanstalkd-${{ matrix.arch }}
       - name: Run beanstalkd -v
-        run: ${{steps.download.outputs.download-path}}/beanstalkd -v
+        run: ${{steps.download.outputs.download-path}}/beanstalkd-${{ matrix.arch }} -v
 
       - name: Install dependencies
         run: |
@@ -73,7 +82,7 @@ jobs:
           pip install .
       - name: Run tests
         env:
-          BEANSTALKD_PATH: ${{steps.download.outputs.download-path}}/beanstalkd
+          BEANSTALKD_PATH: ${{steps.download.outputs.download-path}}/beanstalkd-${{ matrix.arch }}
         run: make test
   pystalk:
     name: Test Pystalk Python
@@ -82,6 +91,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.10" ]
+        arch: [ amd64, arm64 ]
     needs:
       - build
     steps:
@@ -95,14 +105,14 @@ jobs:
       - uses: actions/download-artifact@v4
         id: download
         with:
-          name: beanstalkd
-      - name: Make beanstalkd executable
-        run: chmod +x ${{steps.download.outputs.download-path}}/beanstalkd
+          name: beanstalkd-${{ matrix.arch }}
+      - name: Make beanstalkd executable for ${{ matrix.arch }}
+        run: chmod +x ${{steps.download.outputs.download-path}}/beanstalkd-${{ matrix.arch }}
       - name: Run beanstalkd -v
-        run: ${{steps.download.outputs.download-path}}/beanstalkd -v
+        run: ${{steps.download.outputs.download-path}}/beanstalkd-${{ matrix.arch }} -v
       - name: Install dependencies
         run: python -m pip install -r requirements-tests.txt -e .
       - name: Run tests
         env:
-          BEANSTALKD_PATH: ${{steps.download.outputs.download-path}}/beanstalkd
+          BEANSTALKD_PATH: ${{steps.download.outputs.download-path}}/beanstalkd-${{ matrix.arch }}
         run: pytest tests/


### PR DESCRIPTION
Ensure that tests are run on both `x86_64` and `aarm64` (corresponding to `linux/amd64` and `linux/arm64`).